### PR TITLE
Added route, ride to vehicle location results

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,23 @@ uvicorn open_bus_stride_api.main:app --reload
 ```
 
 See the API docs at http://localhost:8000/docs
+
+### Manage APIs
+
+All existing APIs from the docs are defined under ```open_bus_stride_api/routers/<base_router_name>.py```
+
+Follow this example to create or edit a simple API for a specific table with filters: 
+
+
+```
+@router.<http_method>("/<api_path>", tags=[<file_name>], response_model=<pydantic_response_model>) // 
+def name(<filtering_params>, limit, offset): # always include limit & offest to allow easy iteration on the data
+    return common.get_list(
+        <db_model>, limit, offset,
+        [   
+            {'type': <filter_type>, 'field': <db_stcruct>.<specific_id>, 'value': <filter_param>},
+        ]
+    )
+```
+
+Filter types are defined at ```open_bus_stride_api/routers/common.py -> get_list_query_filter_<filter_type>``` (e.g.: 'equal', 'date_in_range')

--- a/open_bus_stride_api/routers/gtfs_stops.py
+++ b/open_bus_stride_api/routers/gtfs_stops.py
@@ -25,13 +25,14 @@ class GtfsStopPydanticModel(pydantic.BaseModel):
 @router.get("/list", tags=['gtfs'], response_model=typing.List[GtfsStopPydanticModel])
 def list_(limit: int = None, offset: int = None,
           date_from: datetime.date = None, date_to: datetime.date = None,
-          code: int = None):
+          code: int = None, city: str = None):
     return common.get_list(
         GtfsStop, limit, offset,
         [
             {'type': 'datetime_from', 'field': GtfsStop.date, 'value': date_from},
             {'type': 'datetime_to', 'field': GtfsStop.date, 'value': date_to},
             {'type': 'equals', 'field': GtfsStop.code, 'value': code},
+            {'type': 'equals', 'field': GtfsStop.city, 'value': city},
         ]
     )
 

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -1,11 +1,14 @@
 import typing
 import datetime
+import sqlalchemy
 
 import pydantic
 from fastapi import APIRouter
 
 from open_bus_stride_db.model.siri_vehicle_location import SiriVehicleLocation
+from open_bus_stride_db import model
 
+from . import siri_rides, siri_routes
 from . import common
 
 
@@ -24,13 +27,44 @@ class SiriVehicleLocationPydanticModel(pydantic.BaseModel):
     distance_from_journey_start: int
     distance_from_siri_ride_stop_meters: typing.Optional[int]
 
+siri_route_related_model = common.PydanticRelatedModel(
+    'siri_route__', siri_routes.SiriRoutePydanticModel, ['id']
+)
+siri_ride_related_model = common.PydanticRelatedModel(
+    'siri_ride__', siri_rides.SiriRidePydanticModel, ['id']
+)
 
-@router.get("/list", tags=['siri'], response_model=typing.List[SiriVehicleLocationPydanticModel])
+SiriVehicleLocationWithRelatedPydanticModel = common.pydantic_create_model_with_related(
+    'SiriVehicleLocationWithRelatedPydanticModel',
+    SiriVehicleLocationPydanticModel,
+    siri_route_related_model,
+    siri_ride_related_model,
+)
+
+def _post_session_query_hook(session_query: sqlalchemy.orm.Query):
+    return (
+        session_query
+        .select_from(model.SiriVehicleLocation)
+        .add_entity(model.SiriRide)
+        .add_entity(model.SiriRoute)
+        .join(model.SiriRideStop)
+        .join(model.SiriRide)
+        .join(model.SiriRoute, model.SiriRoute.id == model.SiriRide.siri_route_id)
+    )
+
+def _convert_to_dict(obj: model.SiriVehicleLocation):
+    siri_vehicle_location, siri_ride, siri_route = obj
+    res = siri_vehicle_location.__dict__
+    siri_route_related_model.add_orm_obj_to_dict_res(siri_route, res)
+    siri_ride_related_model.add_orm_obj_to_dict_res(siri_ride, res)
+    return res
+
+@router.get("/list", tags=['siri'], response_model=typing.List[SiriVehicleLocationWithRelatedPydanticModel])
 def list_(limit: int = None, offset: int = None,
           siri_vehicle_location_ids: str = None,
           siri_snapshot_ids: str = None, siri_ride_stop_ids: str = None,
           recorded_at_time_from: datetime.datetime = None, recorded_at_time_to: datetime.datetime = None,
-          order_by: str = None):
+          order_by: str = None, siri_routes__line_ref: str = None):
     """
     * siri_vehicle_location_ids: comma-separated list
     * siri_snapshot_ids: comma-separated list
@@ -41,13 +75,16 @@ def list_(limit: int = None, offset: int = None,
     return common.get_list(
         SiriVehicleLocation, limit, offset,
         [
+            {'type': 'equals', 'field': model.SiriRoute.line_ref, 'value': siri_routes__line_ref},
             {'type': 'in', 'field': SiriVehicleLocation.id, 'value': siri_vehicle_location_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_snapshot_id, 'value': siri_snapshot_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_ride_stop_id, 'value': siri_ride_stop_ids},
             {'type': 'datetime_from', 'field': SiriVehicleLocation.recorded_at_time, 'value': recorded_at_time_from},
             {'type': 'datetime_to', 'field': SiriVehicleLocation.recorded_at_time, 'value': recorded_at_time_to},
         ],
-        order_by=order_by
+        order_by=order_by,
+        post_session_query_hook=_post_session_query_hook,
+        convert_to_dict=_convert_to_dict,
     )
 
 

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -64,7 +64,10 @@ def list_(limit: int = None, offset: int = None,
           siri_vehicle_location_ids: str = None,
           siri_snapshot_ids: str = None, siri_ride_stop_ids: str = None,
           recorded_at_time_from: datetime.datetime = None, recorded_at_time_to: datetime.datetime = None,
-          order_by: str = None, siri_routes__line_ref: str = None):
+          order_by: str = None, siri_routes__line_ref: str = None, siri_routes__operator_ref: str = None,
+          siri_rides__schedualed_start_time_from: datetime.datetime = None,
+          siri_rides__schedualed_start_time_to: datetime.datetime = None,
+          ):
     """
     * siri_vehicle_location_ids: comma-separated list
     * siri_snapshot_ids: comma-separated list
@@ -76,6 +79,9 @@ def list_(limit: int = None, offset: int = None,
         SiriVehicleLocation, limit, offset,
         [
             {'type': 'equals', 'field': model.SiriRoute.line_ref, 'value': siri_routes__line_ref},
+            {'type': 'equals', 'field': model.SiriRoute.operator_ref, 'value': siri_routes__operator_ref},
+            {'type': 'datetime_to', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_to},
+            {'type': 'datetime_from', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_from},
             {'type': 'in', 'field': SiriVehicleLocation.id, 'value': siri_vehicle_location_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_snapshot_id, 'value': siri_snapshot_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_ride_stop_id, 'value': siri_ride_stop_ids},


### PR DESCRIPTION
As discussed with the data science team, vehicle location data is irrelevant without the ride & route context. Therefore, added them to all the vehicle locations queries responses.

Based to the new schema, joining vehicle_location->siri_ride_stop->siri_ride->siri_route

Example user-cases (as discussed with the ds team):
* Draw a map of locations of a specific line ref.
* Verifying a compliant about a bus that didn't follow its planed route in a specific line ref and date.

Manual tests done:
* Valitation of the output SQL query correctness directly Infront of the db
* Validations to each of the new filters infront of the swagger