### PR TITLE
Added route, ride ids to output & as filters

### DIFF
--- a/open_bus_stride_api/routers/common.py
+++ b/open_bus_stride_api/routers/common.py
@@ -101,13 +101,16 @@ def get_item(db_model, field, value):
 
 class PydanticRelatedModel():
 
-    def __init__(self, field_name_prefix, pydantic_model, exclude_field_names=None):
+    def __init__(self, field_name_prefix, pydantic_model, exclude_field_names=None, include_field_names=None):
         self.field_name_prefix = field_name_prefix
         self.pydantic_model = pydantic_model
         self.exclude_field_names = exclude_field_names
+        self.include_field_names = include_field_names
 
     def update_create_model_kwargs(self, kwargs):
         for name, field in self.pydantic_model.__fields__.items():
+            if self.include_field_names and name not in self.include_field_names:
+                continue
             if self.exclude_field_names and name in self.exclude_field_names:
                 continue
             default = field.default

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter
 from open_bus_stride_db.model.siri_vehicle_location import SiriVehicleLocation
 from open_bus_stride_db import model
 
-from . import siri_rides, siri_routes
+from . import siri_rides, siri_routes, siri_snapshots
 from . import common
 
 
@@ -28,15 +28,23 @@ class SiriVehicleLocationPydanticModel(pydantic.BaseModel):
     distance_from_siri_ride_stop_meters: typing.Optional[int]
 
 siri_route_related_model = common.PydanticRelatedModel(
-    'siri_route__', siri_routes.SiriRoutePydanticModel, ['id']
+    'siri_route__', siri_routes.SiriRoutePydanticModel
 )
 siri_ride_related_model = common.PydanticRelatedModel(
-    'siri_ride__', siri_rides.SiriRidePydanticModel
+    'siri_ride__', siri_rides.SiriRidePydanticModel, [
+        'siri_route_id', 'updated_first_last_vehicle_locations', 'updated_duration_minutes',
+        'journey_gtfs_ride_id', 'route_gtfs_ride_id'
+    ]
+)
+siri_snapshot_related_model = common.PydanticRelatedModel(
+    'siri_snapshot__', siri_snapshots.SiriSnapshotPydanticModel,
+    include_field_names=['snapshot_id']
 )
 
 SiriVehicleLocationWithRelatedPydanticModel = common.pydantic_create_model_with_related(
     'SiriVehicleLocationWithRelatedPydanticModel',
     SiriVehicleLocationPydanticModel,
+    siri_snapshot_related_model,
     siri_route_related_model,
     siri_ride_related_model,
 )
@@ -45,16 +53,19 @@ def _post_session_query_hook(session_query: sqlalchemy.orm.Query):
     return (
         session_query
         .select_from(model.SiriVehicleLocation)
+        .add_entity(model.SiriSnapshot)
         .add_entity(model.SiriRide)
         .add_entity(model.SiriRoute)
         .join(model.SiriRideStop)
         .join(model.SiriRide)
         .join(model.SiriRoute, model.SiriRoute.id == model.SiriRide.siri_route_id)
+        .join(model.SiriSnapshot)
     )
 
 def _convert_to_dict(obj: model.SiriVehicleLocation):
-    siri_vehicle_location, siri_ride, siri_route = obj
+    siri_vehicle_location, siri_snapshot, siri_ride, siri_route = obj
     res = siri_vehicle_location.__dict__
+    siri_snapshot_related_model.add_orm_obj_to_dict_res(siri_snapshot, res)
     siri_route_related_model.add_orm_obj_to_dict_res(siri_route, res)
     siri_ride_related_model.add_orm_obj_to_dict_res(siri_ride, res)
     return res
@@ -94,6 +105,7 @@ def list_(limit: int = None, offset: int = None,
         order_by=order_by,
         post_session_query_hook=_post_session_query_hook,
         convert_to_dict=_convert_to_dict,
+        max_limit=100
     )
 
 

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -67,7 +67,7 @@ def list_(limit: int = None, offset: int = None,
           order_by: str = None, siri_routes__line_ref: str = None, siri_routes__operator_ref: str = None,
           siri_rides__schedualed_start_time_from: datetime.datetime = None,
           siri_rides__schedualed_start_time_to: datetime.datetime = None,
-          siri_rides__id: int = None, siri_routes__id: int = None,
+          siri_rides__ids: str = None, siri_routes__ids: str = None,
           ):
     """
     * siri_vehicle_location_ids: comma-separated list
@@ -81,10 +81,10 @@ def list_(limit: int = None, offset: int = None,
         [
             {'type': 'equals', 'field': model.SiriRoute.line_ref, 'value': siri_routes__line_ref},
             {'type': 'equals', 'field': model.SiriRoute.operator_ref, 'value': siri_routes__operator_ref},
-            {'type': 'equals', 'field': model.SiriRoute.id, 'value': siri_routes__id},
+            {'type': 'in', 'field': model.SiriRoute.id, 'value': siri_routes__ids},
             {'type': 'datetime_to', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_to},
             {'type': 'datetime_from', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_from},
-            {'type': 'equals', 'field': model.SiriRide.id, 'value': siri_rides__id},
+            {'type': 'in', 'field': model.SiriRide.id, 'value': siri_rides__ids},
             {'type': 'in', 'field': SiriVehicleLocation.id, 'value': siri_vehicle_location_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_snapshot_id, 'value': siri_snapshot_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_ride_stop_id, 'value': siri_ride_stop_ids},

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -31,7 +31,7 @@ siri_route_related_model = common.PydanticRelatedModel(
     'siri_route__', siri_routes.SiriRoutePydanticModel, ['id']
 )
 siri_ride_related_model = common.PydanticRelatedModel(
-    'siri_ride__', siri_rides.SiriRidePydanticModel, ['id']
+    'siri_ride__', siri_rides.SiriRidePydanticModel
 )
 
 SiriVehicleLocationWithRelatedPydanticModel = common.pydantic_create_model_with_related(
@@ -67,6 +67,7 @@ def list_(limit: int = None, offset: int = None,
           order_by: str = None, siri_routes__line_ref: str = None, siri_routes__operator_ref: str = None,
           siri_rides__schedualed_start_time_from: datetime.datetime = None,
           siri_rides__schedualed_start_time_to: datetime.datetime = None,
+          siri_rides__id: int = None, siri_routes__id: int = None,
           ):
     """
     * siri_vehicle_location_ids: comma-separated list
@@ -80,8 +81,10 @@ def list_(limit: int = None, offset: int = None,
         [
             {'type': 'equals', 'field': model.SiriRoute.line_ref, 'value': siri_routes__line_ref},
             {'type': 'equals', 'field': model.SiriRoute.operator_ref, 'value': siri_routes__operator_ref},
+            {'type': 'equals', 'field': model.SiriRoute.id, 'value': siri_routes__id},
             {'type': 'datetime_to', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_to},
             {'type': 'datetime_from', 'field': model.SiriRide.scheduled_start_time, 'value': siri_rides__schedualed_start_time_from},
+            {'type': 'equals', 'field': model.SiriRide.id, 'value': siri_rides__id},
             {'type': 'in', 'field': SiriVehicleLocation.id, 'value': siri_vehicle_location_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_snapshot_id, 'value': siri_snapshot_ids},
             {'type': 'in', 'field': SiriVehicleLocation.siri_ride_stop_id, 'value': siri_ride_stop_ids},


### PR DESCRIPTION
supersedes #8 

fixes hasadna/open-bus#381

changes to siri_vehicle_locations:

* added `siri_route__id`
* removed unnecesary fields from siri_ride related data - these fields may confuse end-users regarding their meaning, they are mostly intended for internal processing
* added `siri_snapshot__snapshot_id`
* added `siri_routes__ids`, `siri_rides__ids, filtering options
* reduced max_limit to 100 as requests were taking too long to complete