### PR TITLE
add count argument to all list methods

### DIFF
--- a/open_bus_stride_api/routers/gtfs_ride_stops.py
+++ b/open_bus_stride_api/routers/gtfs_ride_stops.py
@@ -35,6 +35,7 @@ SQL_MODEL = model.GtfsRideStop
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           gtfs_stop_ids: str = common.param_filter_list('gtfs stop id'),
           gtfs_ride_ids: str = common.param_filter_list('gtfs ride id')):
     return common.get_list(
@@ -43,7 +44,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'in', 'field': model.GtfsRideStop.gtfs_stop_id, 'value': gtfs_stop_ids},
             {'type': 'in', 'field': model.GtfsRideStop.gtfs_ride_id, 'value': gtfs_ride_ids},
         ],
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/gtfs_rides.py
+++ b/open_bus_stride_api/routers/gtfs_rides.py
@@ -28,6 +28,7 @@ SQL_MODEL = GtfsRide
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           gtfs_route_id: int = common.param_filter_equals('gtfs route id'),
           journey_ref_prefix: str = common.param_filter_prefix('journey ref')):
     return common.get_list(
@@ -36,7 +37,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'equals', 'field': GtfsRide.gtfs_route_id, 'value': gtfs_route_id},
             {'type': 'prefix', 'field': GtfsRide.journey_ref, 'value': journey_ref_prefix},
         ],
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/gtfs_routes.py
+++ b/open_bus_stride_api/routers/gtfs_routes.py
@@ -37,6 +37,7 @@ SQL_MODEL = GtfsRoute
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           date_from: datetime.date = common.param_filter_date_from('date'),
           date_to: datetime.date = common.param_filter_date_to('date'),
           line_refs: str = common.param_filter_list('line ref'),
@@ -65,7 +66,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'equals', 'field': GtfsRoute.route_type, 'value': route_type},
         ],
         order_by=order_by,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/gtfs_stops.py
+++ b/open_bus_stride_api/routers/gtfs_stops.py
@@ -33,6 +33,7 @@ SQL_MODEL = GtfsStopPydanticModel
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           date_from: datetime.date = common.param_filter_date_from('date'),
           date_to: datetime.date = common.param_filter_date_to('date'),
           code: int = common.param_filter_equals('code'),
@@ -45,7 +46,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'equals', 'field': GtfsStop.code, 'value': code},
             {'type': 'equals', 'field': GtfsStop.city, 'value': city},
         ],
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_ride_stops.py
+++ b/open_bus_stride_api/routers/siri_ride_stops.py
@@ -94,6 +94,7 @@ def _convert_to_dict(obj: model.SiriRideStop):
 @common.router_list(router, TAG, SiriRideStopWithRelatedPydanticModel, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           siri_stop_ids: str = common.param_filter_list('siri stop id'),
           siri_ride_ids: str = common.param_filter_list('siri ride id'),
           siri_vehicle_location__lon__greater_or_equal: float = common.param_filter_greater_or_equal(
@@ -125,7 +126,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
         order_by=order_by,
         post_session_query_hook=_post_session_query_hook,
         convert_to_dict=_convert_to_dict,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_rides.py
+++ b/open_bus_stride_api/routers/siri_rides.py
@@ -43,6 +43,7 @@ def _post_session_query_hook(session_query: sqlalchemy.orm.Query):
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(max_limit=LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           siri_route_ids: str = common.param_filter_list('siri route ids'),
           siri_route__line_refs: str = common.param_filter_list('siri route line refs'),
           siri_route__operator_refs: str = common.param_filter_list('siri route operator refs'),
@@ -66,7 +67,8 @@ def list_(limit: int = common.param_limit(max_limit=LIST_MAX_LIMIT),
         ],
         order_by=order_by,
         post_session_query_hook=_post_session_query_hook,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_routes.py
+++ b/open_bus_stride_api/routers/siri_routes.py
@@ -26,6 +26,7 @@ SQL_MODEL = SiriRoute
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           line_refs: str = common.param_filter_list('line ref'),
           operator_refs: str = common.param_filter_list('operator ref'),
           order_by: str = common.param_order_by()):
@@ -36,7 +37,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'in', 'field': SiriRoute.operator_ref, 'value': operator_refs},
         ],
         order_by=order_by,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_snapshots.py
+++ b/open_bus_stride_api/routers/siri_snapshots.py
@@ -40,6 +40,7 @@ SQL_MODEL = SiriSnapshot
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           snapshot_id_prefix: str = common.param_filter_prefix('snapshot id'),
           order_by: str = common.param_order_by()):
     return common.get_list(
@@ -48,7 +49,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'prefix', 'field': SiriSnapshot.snapshot_id, 'value': snapshot_id_prefix},
         ],
         order_by=order_by,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_stops.py
+++ b/open_bus_stride_api/routers/siri_stops.py
@@ -27,6 +27,7 @@ SQL_MODEL = SiriStop
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           codes: str = common.param_filter_list('stop code'),
           order_by: str = common.param_order_by()):
     return common.get_list(
@@ -35,7 +36,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
             {'type': 'in', 'field': SiriStop.code, 'value': codes},
         ],
         order_by=order_by,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 

--- a/open_bus_stride_api/routers/siri_vehicle_locations.py
+++ b/open_bus_stride_api/routers/siri_vehicle_locations.py
@@ -82,6 +82,7 @@ def _convert_to_dict(obj: model.SiriVehicleLocation):
 @common.router_list(router, TAG, SiriVehicleLocationWithRelatedPydanticModel, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
           offset: int = common.param_offset(),
+          get_count: bool = common.param_get_count(),
           siri_vehicle_location_ids: str = common.param_filter_list('siri vehicle location id'),
           siri_snapshot_ids: str = common.param_filter_list('siri snapshot id'),
           siri_ride_stop_ids: str = common.param_filter_list('siri ride stop id'),
@@ -121,7 +122,8 @@ def list_(limit: int = common.param_limit(LIST_MAX_LIMIT),
         order_by=order_by,
         post_session_query_hook=_post_session_query_hook,
         convert_to_dict=_convert_to_dict,
-        max_limit=LIST_MAX_LIMIT
+        max_limit=LIST_MAX_LIMIT,
+        get_count=get_count,
     )
 
 


### PR DESCRIPTION
fixes hasadna/open-bus#395

added option to get total number of results for all list methods by adding `&get_count=true` to any list method, this will return just the number of results