### PR TITLE
gtfs_ride_agg API adaptations to the new view

### DIFF
--- a/open_bus_stride_api/routers/common.py
+++ b/open_bus_stride_api/routers/common.py
@@ -29,6 +29,8 @@ FILTER_DOCS = {
         'Note that all date/times must have a timezone specification.',
     "date_from": 'Filter by {what_singular}. Only return items which have a date after or equals to given value. Format: "YYYY-MM-DD", e.g. "2021-11-03".',
     "date_to": 'Filter by {what_singular}. Only return items which have a date before or equals to given value. Format: "YYYY-MM-DD", e.g. "2021-11-03".',
+    "hour_from": 'Filter by {what_singular}. Only return items which have an hour date after or equals to given value. Format: 0(12AM)-23',
+    "hour_to": 'Filter by {what_singular}. Only return items which have a date before or equals to given value. Format: 0(12AM)-23',
     "greater_or_equal": 'Filter by {what_singular}. Only return items which have a numeric value greater than or equal to given value',
     "lower_or_equal": 'Filter by {what_singular}. Only return items which have a numeric value lower than or equal to given value',
 }

--- a/open_bus_stride_api/routers/gtfs_rides_agg.py
+++ b/open_bus_stride_api/routers/gtfs_rides_agg.py
@@ -124,5 +124,4 @@ def group_by_(date_from: datetime.date = common.doc_param('date', filter_type='d
 
     sql += f" group by {', '.join(group_by_fields)}"
 
-    print(sql)
     return sql_route.list_(sql, sql_params, None, None, None, None, None, True)

--- a/open_bus_stride_api/routers/gtfs_rides_agg.py
+++ b/open_bus_stride_api/routers/gtfs_rides_agg.py
@@ -15,7 +15,7 @@ router = APIRouter()
 
 class GtfsRidesAggPydanticModel(pydantic.BaseModel):
     gtfs_route_id: int
-    gtfs_route_date: datetime.date
+    gtfs_route_hour: datetime.date
     num_planned_rides: int
     num_actual_rides: int
     operator_ref: int
@@ -23,6 +23,7 @@ class GtfsRidesAggPydanticModel(pydantic.BaseModel):
 
 class GtfsRidesAggGroupByPydanticModel(pydantic.BaseModel):
     gtfs_route_date: typing.Optional[datetime.date]
+    gtfs_route_hour: typing.Optional[datetime.date]
     operator_ref: typing.Optional[int]
     day_of_week: typing.Optional[str]
     total_routes: int
@@ -36,7 +37,7 @@ TAG = 'aggregations'
 PYDANTIC_MODEL = GtfsRidesAggPydanticModel
 GROUP_BY_PYDANTIC_MODEL = GtfsRidesAggGroupByPydanticModel
 DEFAULT_LIMIT = 1000
-ALLOWED_GROUP_BY_FIELDS = ['gtfs_route_date', 'operator_ref', 'day_of_week']
+ALLOWED_GROUP_BY_FIELDS = ['gtfs_route_date', 'gtfs_route_hour', 'operator_ref', 'day_of_week']
 
 
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
@@ -44,30 +45,42 @@ def list_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
           offset: int = common.param_offset(),
           get_count: bool = common.param_get_count(),
           date_from: datetime.date = common.doc_param('date', filter_type='date_from', default=...),
-          date_to: datetime.date = common.doc_param('date', filter_type='date_to', default=...)):
-    sql = dedent("""
+          date_to: datetime.date = common.doc_param('date', filter_type='date_to', default=...),
+          exclude_hours_from: int = common.doc_param('hour', filter_type='hour_from', description="Hours to exclude from search, currently used to filter out edge cases."),
+          exclude_hours_to: int = common.doc_param('hour', filter_type='hour_to', description="Hours to exclude from search, currently used to filter out edge cases.")):
+    sql = """
         select
             agg.gtfs_route_id,
-            agg.gtfs_route_date,
+            agg.gtfs_route_hour,
             agg.num_planned_rides,
             agg.num_actual_rides,
             rt.operator_ref
-        from gtfs_rides_agg agg, gtfs_route rt
+        from gtfs_rides_agg_by_hour agg, gtfs_route rt
         where
             agg.gtfs_route_id = rt.id
-            and agg.gtfs_route_date >= :date_from
-            and agg.gtfs_route_date <= :date_to
-    """)
+            and date_trunc('day', agg.gtfs_route_hour) >= :date_from
+            and date_trunc('day', agg.gtfs_route_hour) <= :date_to   
+    """
     sql_params = {
         'date_from': date_from,
         'date_to': date_to,
     }
-    return sql_route.list_(sql, sql_params, DEFAULT_LIMIT, limit, offset, get_count, 'gtfs_route_date asc, gtfs_route_id asc', False)
+
+    if exclude_hours_from:
+        sql += " and not date_part('hour', agg.gtfs_route_hour) >= :exclude_hour_from"
+        sql_params['exclude_hour_from'] = exclude_hours_from
+    if exclude_hours_to:
+        sql += " and not date_part('hour', agg.gtfs_route_hour) <= :exclude_hour_to"
+        sql_params['exclude_hour_to'] = exclude_hours_to
+
+    return sql_route.list_(dedent(sql), sql_params, DEFAULT_LIMIT, limit, offset, get_count, 'gtfs_route_hour asc, gtfs_route_id asc', False)
 
 
 @router.get("/group_by", tags=[TAG], response_model=typing.List[GROUP_BY_PYDANTIC_MODEL], description=f'{WHAT_SINGULAR} grouped by given fields.')
 def group_by_(date_from: datetime.date = common.doc_param('date', filter_type='date_from', default=...),
               date_to: datetime.date = common.doc_param('date', filter_type='date_to', default=...),
+              exclude_hours_from: int = common.doc_param('hour', filter_type='hour_from', description="Hours to exclude from search, currently used to filter out edge cases."),
+              exclude_hours_to: int = common.doc_param('hour', filter_type='hour_to', description="Hours to exclude from search, currently used to filter out edge cases."),
               group_by: str = fastapi.Query(..., description=f'Comma-separated list of fields to group by. Valid values: {", ".join(ALLOWED_GROUP_BY_FIELDS)}.')
               ):
     group_by = [f.strip() for f in group_by.split(',') if f.strip()]
@@ -75,10 +88,12 @@ def group_by_(date_from: datetime.date = common.doc_param('date', filter_type='d
     select_fields = []
     group_by_fields = []
     for fieldname in group_by:
-        if fieldname == 'gtfs_route_date':
-            full_fieldname = 'agg.gtfs_route_date'
+        if fieldname == 'gtfs_route_hour':
+            full_fieldname = 'agg.gtfs_route_hour'
+        elif fieldname == 'gtfs_route_date':
+            full_fieldname = "date_trunc('day', agg.gtfs_route_hour)"
         elif fieldname == 'day_of_week':
-            full_fieldname = "trim(lower(to_char(agg.gtfs_route_date, 'DAY')))"
+            full_fieldname = "trim(lower(to_char(agg.gtfs_route_hour, 'DAY')))"
         else:
             full_fieldname = f'rt.{fieldname}'
         select_fields.append(f'{full_fieldname} as {fieldname}')
@@ -89,15 +104,25 @@ def group_by_(date_from: datetime.date = common.doc_param('date', filter_type='d
             count(1) as total_routes,
             sum(agg.num_planned_rides) as total_planned_rides,
             sum(agg.num_actual_rides) as total_actual_rides
-        from gtfs_rides_agg agg, gtfs_route rt
+        from gtfs_rides_agg_by_hour agg, gtfs_route rt
         where
             agg.gtfs_route_id = rt.id
-            and agg.gtfs_route_date >= :date_from
-            and agg.gtfs_route_date <= :date_to
-        group by {', '.join(group_by_fields)}
+            and date_trunc('day', agg.gtfs_route_hour) >= :date_from
+            and date_trunc('day', agg.gtfs_route_hour) <= :date_to
     """)
     sql_params = {
         'date_from': date_from,
         'date_to': date_to,
     }
+
+    if exclude_hours_from:
+        sql += " and not date_part('hour', agg.gtfs_route_hour) >= :exclude_hour_from"
+        sql_params['exclude_hour_from'] = exclude_hours_from
+    if exclude_hours_to:
+        sql += " and not date_part('hour', agg.gtfs_route_hour) <= :exclude_hour_to"
+        sql_params['exclude_hour_to'] = exclude_hours_to
+
+    sql += f" group by {', '.join(group_by_fields)}"
+
+    print(sql)
     return sql_route.list_(sql, sql_params, None, None, None, None, None, True)


### PR DESCRIPTION
This PR depends on https://github.com/hasadna/open-bus-stride-db/pull/21 being deployed first

API changes:
*  Added `exclude_hours_from\to` filtering - which is needed to filter out easily hours in the FE, because of edge cases we currently define as known issues.
*  `group_by` is backwards compatible - adapted the option to group by day, added the option to group by hour
*  `list` will now return the rows by hour granularity

Testing:
* Manually ran the queries (currently replaced the view with the query) and validated the results