### PR TITLE
Add agg by line ref to gtfs_ride_agg/group_by

### DIFF
--- a/open_bus_stride_api/routers/gtfs_rides_agg.py
+++ b/open_bus_stride_api/routers/gtfs_rides_agg.py
@@ -81,9 +81,7 @@ def list_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
 
 
 @router.get("/group_by", tags=[TAG], response_model=typing.List[GROUP_BY_PYDANTIC_MODEL], description=f'{WHAT_SINGULAR} grouped by given fields.')
-def group_by_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
-              offset: int = common.param_offset(),
-              date_from: datetime.date = common.doc_param('date', filter_type='date_from', default=...),
+def group_by_(date_from: datetime.date = common.doc_param('date', filter_type='date_from', default=...),
               date_to: datetime.date = common.doc_param('date', filter_type='date_to', default=...),
               exclude_hours_from: int = common.doc_param('hour', filter_type='hour_from', description="Hours to exclude from search, currently used to filter out edge cases."),
               exclude_hours_to: int = common.doc_param('hour', filter_type='hour_to', description="Hours to exclude from search, currently used to filter out edge cases."),
@@ -136,4 +134,4 @@ def group_by_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
 
     print(sql)
 
-    return sql_route.list_(sql, sql_params, None, limit, offset, None, None, True)
+    return sql_route.list_(sql, sql_params, None, None, None, None, None, True)

--- a/open_bus_stride_api/routers/gtfs_rides_agg.py
+++ b/open_bus_stride_api/routers/gtfs_rides_agg.py
@@ -37,7 +37,7 @@ TAG = 'aggregations'
 PYDANTIC_MODEL = GtfsRidesAggPydanticModel
 GROUP_BY_PYDANTIC_MODEL = GtfsRidesAggGroupByPydanticModel
 DEFAULT_LIMIT = 1000
-ALLOWED_GROUP_BY_FIELDS = ['gtfs_route_date', 'gtfs_route_hour', 'operator_ref', 'day_of_week']
+ALLOWED_GROUP_BY_FIELDS = ['gtfs_route_date', 'gtfs_route_hour', 'operator_ref', 'day_of_week', 'line_ref']
 
 
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)


### PR DESCRIPTION
When adding grouping by line_ref, route_short_name & route_long_name are also returned (I saw some edge cases where there were slight changes in the long name across time, this is why the "json_agg disctinct" is needed.

@NoamGaash  -
*  note that you should always group by both `line_ref,operator_ref`
* I discussed with @OriHoch about the performance issue when using steaming for downloading, and he said that the problem is with the fastapi swagger, and it should be fine when using the URL directly from the FE. therefore I did not add limit and offset for now as it is tricky using it with the group by. If we'll still see issues when using the FE directly, I'll solve them separately :) 
