### PR TITLE
Add required arrival_time range parameters to /gtfs_stops/list

### DIFF
--- a/open_bus_stride_api/routers/gtfs_ride_stops.py
+++ b/open_bus_stride_api/routers/gtfs_ride_stops.py
@@ -1,7 +1,7 @@
 import datetime
 
 import pydantic
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from open_bus_stride_db import model
 from pydantic.fields import Undefined
@@ -114,6 +114,10 @@ gtfs_ride_stop_list_params = [
 
 @common.add_api_router_list(router, TAG, GtfsRideStopWithRelatedPydanticModel, WHAT_PLURAL, gtfs_ride_stop_list_params)
 def list_(**kwargs):
+    # Validate arrival_time range is no longer than 30 days (to avoid heavy queries)
+    if (kwargs['arrival_time_to'] - kwargs['arrival_time_from']).days > 30:
+        raise HTTPException(status_code=400, detail="Time range is longer than 30 days")
+
     return common.get_list(
         SQL_MODEL, kwargs['limit'], kwargs['offset'],
         [

--- a/open_bus_stride_api/routers/gtfs_ride_stops.py
+++ b/open_bus_stride_api/routers/gtfs_ride_stops.py
@@ -4,6 +4,7 @@ import pydantic
 from fastapi import APIRouter
 
 from open_bus_stride_db import model
+from pydantic.fields import Undefined
 
 from . import common, gtfs_rides, gtfs_stops, gtfs_routes
 
@@ -64,6 +65,16 @@ def _post_session_query_hook(session_query):
 
 
 gtfs_ride_stop_filter_params = [
+    common.RouteParam(
+        'arrival_time_from', datetime.datetime,
+        common.DocParam('arrival time from', filter_type='datetime_from', default=Undefined),
+        {'type': 'datetime_from', 'field': model.GtfsRideStop.arrival_time},
+    ),
+    common.RouteParam(
+        'arrival_time_to', datetime.datetime,
+        common.DocParam('arrival time to', filter_type='datetime_to', default=Undefined),
+        {'type': 'datetime_to', 'field': model.GtfsRideStop.arrival_time},
+    ),
     common.RouteParam(
         'gtfs_stop_ids', str, common.DocParam('gtfs stop id', filter_type='list'),
         {'type': 'in', 'field': model.GtfsRideStop.gtfs_stop_id},

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -15,6 +15,15 @@ def test_gtfs_ride_stops(client):
     )
 
 
+def test_gtfs_ride_stops_list_bad_arrival_time_range(client):
+    res = client.get(
+        '/gtfs_ride_stops/list',
+        params={'arrival_time_from': '2023-01-01T00:00:00+00:00', 'arrival_time_to': '2023-03-01T00:00:00+00:00'},
+    )
+    assert res.status_code == 400, f'expected 400, got {res.status_code}'
+    assert res.json() == {'detail': 'Time range is longer than 30 days'}
+
+
 def test_gtfs_rides(client):
     common.assert_router_list_get(
         client, '/gtfs_rides',

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -10,6 +10,7 @@ def test_gtfs_agencies(client):
 def test_gtfs_ride_stops(client):
     common.assert_router_list_get(
         client, '/gtfs_ride_stops',
+        params={'arrival_time_from': '2023-05-22T02:12:50+00:00', 'arrival_time_to': '2023-05-22T02:18:59+00:00'},
         get_get_count_params=lambda items: {'gtfs_ride_ids': str(items[0]['gtfs_ride_id'])}
     )
 


### PR DESCRIPTION
Solves issue #26

By adding these `arrival_time_to` and `arrival_time_from` parameters, and validating they create a range no longer than 30 days, the query behind the scenes is more efficient.

This is the docs of the endpoint after my changes, with the new 2 requiretd parameters:
![image](https://github.com/hasadna/open-bus-stride-api/assets/53089389/9055217e-c326-4ddb-ab4c-a43c9cae1bea)

A small note is that I didn't find any existing validation for parameters, so I didn't have any code styling to follow. I can obviously apply different code style in the validation area, but for now went for the simplest one.

