### PR TITLE
feat: add automatic client generation from commit message semver fragment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,32 +3,25 @@ on:
   push:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-
-      - name: Clone open-bus-stride-db
-        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-
-      - name: Install dependencies
+          python-version: "3.8"
+      - name: Clone DB and Install Dependencies
         run: |
+          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
           pip install -r requirements-dev.txt
           pip install -r tests/requirements.txt
-
-      - name: Log in to GitHub Container Registry
+      - name: Docker Login
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
-
-      - name: Build Docker image
+      - name: Build Docker Image
         env:
           DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
         run: |
@@ -38,176 +31,74 @@ jobs:
             CACHE_FROM_ARG=""
           fi
           docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app .
-
-      - name: Tag and push Docker image
-        env:
-          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-        run: |
           docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
-          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
 
   test:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-
-      - name: Clone open-bus-stride-db
-        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-
-      - name: Install dependencies
+          python-version: "3.8"
+      - name: Clone DB and Install Dependencies
         run: |
+          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
           pip install -r requirements-dev.txt
           pip install -r tests/requirements.txt
-
-      - name: Start database
-        env:
-          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
-        run: |
-          cd ../open-bus-stride-db
-          docker-compose up -d stride-db
-          . .env && alembic upgrade head
-
-      - name: Run tests
-        env:
-          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+      - name: Run Tests
         run: pytest
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build, test]
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '--no-deploy')
+    needs: test
+    if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-
-      - name: Clone open-bus-stride-db
-        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-
-      - name: Log in to GitHub Container Registry
+          python-version: "3.8"
+      - name: Clone DB and Install Dependencies
+        run: |
+          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
+          pip install -r requirements-dev.txt
+          pip install -r tests/requirements.txt
+      - name: Docker Login
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
-
-      - name: Tag and push latest Docker image
+      - name: Push Docker Images
         env:
           DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
         run: |
-          docker pull "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
-          docker tag "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" "${DOCKER_APP_IMAGE_NAME}:latest"
+          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag app "${DOCKER_APP_IMAGE_NAME}:latest"
           docker push "${DOCKER_APP_IMAGE_NAME}:latest"
-
-      - name: Deploy to Kubernetes
+      - name: Deploy to K8s & Update ETL
         env:
           HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
+          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
           DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
         run: |
-          cd `mktemp -d`
-          echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key
-          chmod 400 hasadna_k8s_deploy_key
-          export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-          git clone git@github.com:hasadna/hasadna-k8s.git
-          cd hasadna-k8s
-          python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml
-          git config --global user.name "Open Bus Stride API CI"
-          git config --global user.email "open-bus-stride-api-ci@localhost"
-          git add apps/openbus/values-hasadna-auto-updated.yaml
-          git commit -m "automatic update of open bus stride api"
-          git push origin master
-
-      - name: Update stride-etl dependency
-        env:
-          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
-        run: |
-          cd `mktemp -d`
-          echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key
-          chmod 400 stride_etl_deploy_key
-          export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-          git clone git@github.com:hasadna/open-bus-stride-etl.git
-          cd open-bus-stride-etl
-          echo "${GITHUB_SHA}" > stride-api-latest-commit.txt
-          git add stride-api-latest-commit.txt
-          git commit -m "automatic update of open bus stride api dependencies"
-          git push origin main
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [build, test]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "latest"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Clone open-bus-stride-db
-        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements-dev.txt
-          pip install -r tests/requirements.txt
-          pip install fastapi uvicorn openapi-generator-cli
-
-      - name: Start database and API server
-        env:
-          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
-        run: |
-          cd ../open-bus-stride-db
-          docker-compose up -d stride-db
-          . .env && alembic upgrade head
-          cd ../../${GITHUB_WORKSPACE}
-          uvicorn main:app --host 0.0.0.0 --port 8000 &
-          sleep 10 # Wait for server to start
-
-      - name: Generate TypeScript client
-        run: |
-          mkdir -p npm-package
-          openapi-generator-cli generate \
-            -i http://localhost:8000/openapi.json \
-            -g typescript-axios \
-            -o npm-package \
-            --additional-properties=supportsES6=true,npmName=@hasadna/open-bus-stride-api-client
-          cd npm-package
-          npm install typescript --save-dev
-          npm install axios
-          npx tsc --init
-          npm install
-
-      - name: Set package version
-        run: |
-          cd npm-package
-          SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-7)
-          VERSION="1.0.0-$SHORT_SHA"
-          npm version $VERSION --no-git-tag-version
-
-      - name: Check if version exists and publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          cd npm-package
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-          if npm view @hasadna/open-bus-stride-api-client@$VERSION > /dev/null 2>&1; then
-            echo "Version $VERSION already exists, skipping publish"
-          else
-            npm publish --access public
+          if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
+            cd `mktemp -d`
+            echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key
+            chmod 400 hasadna_k8s_deploy_key
+            export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+            git clone git@github.com:hasadna/hasadna-k8s.git
+            cd hasadna-k8s
+            python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml
+            git config --global user.name "Open Bus Stride API CI"
+            git config --global user.email "open-bus-stride-api-ci@localhost"
+            git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api"
+            git push origin master
+            echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key
+            chmod 400 stride_etl_deploy_key
+            export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+            git clone git@github.com:hasadna/open-bus-stride-etl.git
+            cd open-bus-stride-etl
+            echo "${GITHUB_SHA}" > stride-api-latest-commit.txt
+            git add stride-api-latest-commit.txt
+            git commit -m "automatic update of open bus stride api dependencies"
+            git push origin main
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,56 +4,210 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 jobs:
-  ci:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.8'
-    - env:
-        DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
-        SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
-        STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
-      run: |
-        git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db &&\
-        pip install -r requirements-dev.txt &&\
-        pip install -r tests/requirements.txt &&\
-        echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin &&\
-        if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
-          CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"
-        else
-          CACHE_FROM_ARG=""
-        fi &&\
-        docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app . &&\
-        docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
-        docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
-        pytest &&\
-        if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
-          docker tag app "${DOCKER_APP_IMAGE_NAME}:latest" &&\
-          docker push "${DOCKER_APP_IMAGE_NAME}:latest" &&\
-          if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
-            cd `mktemp -d` &&\
-            echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key &&\
-            chmod 400 hasadna_k8s_deploy_key &&\
-            export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
-            git clone git@github.com:hasadna/hasadna-k8s.git &&\
-            cd hasadna-k8s &&\
-            python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml &&\
-            git config --global user.name "Open Bus Stride API CI" &&\
-            git config --global user.email "open-bus-stride-api-ci@localhost" &&\
-            git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api" &&\
-            git push origin master &&\
-            echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key &&\
-            chmod 400 stride_etl_deploy_key &&\
-            export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
-            git clone git@github.com:hasadna/open-bus-stride-etl.git &&\
-            cd open-bus-stride-etl &&\
-            echo "${GITHUB_SHA}" > stride-api-latest-commit.txt &&\
-            git add stride-api-latest-commit.txt &&\
-            git commit -m "automatic update of open bus stride api dependencies" &&\
-            git push origin main
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Clone open-bus-stride-db
+        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -r tests/requirements.txt
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
+
+      - name: Build Docker image
+        env:
+          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
+        run: |
+          if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
+            CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"
+          else
+            CACHE_FROM_ARG=""
           fi
-        fi
+          docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app .
+
+      - name: Tag and push Docker image
+        env:
+          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
+        run: |
+          docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
+          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Clone open-bus-stride-db
+        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -r tests/requirements.txt
+
+      - name: Start database
+        env:
+          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+        run: |
+          cd ../open-bus-stride-db
+          docker-compose up -d stride-db
+          . .env && alembic upgrade head
+
+      - name: Run tests
+        env:
+          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+        run: pytest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '--no-deploy')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Clone open-bus-stride-db
+        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
+
+      - name: Tag and push latest Docker image
+        env:
+          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
+        run: |
+          docker pull "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" "${DOCKER_APP_IMAGE_NAME}:latest"
+          docker push "${DOCKER_APP_IMAGE_NAME}:latest"
+
+      - name: Deploy to Kubernetes
+        env:
+          HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
+          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
+        run: |
+          cd `mktemp -d`
+          echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key
+          chmod 400 hasadna_k8s_deploy_key
+          export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+          git clone git@github.com:hasadna/hasadna-k8s.git
+          cd hasadna-k8s
+          python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml
+          git config --global user.name "Open Bus Stride API CI"
+          git config --global user.email "open-bus-stride-api-ci@localhost"
+          git add apps/openbus/values-hasadna-auto-updated.yaml
+          git commit -m "automatic update of open bus stride api"
+          git push origin master
+
+      - name: Update stride-etl dependency
+        env:
+          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
+        run: |
+          cd `mktemp -d`
+          echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key
+          chmod 400 stride_etl_deploy_key
+          export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+          git clone git@github.com:hasadna/open-bus-stride-etl.git
+          cd open-bus-stride-etl
+          echo "${GITHUB_SHA}" > stride-api-latest-commit.txt
+          git add stride-api-latest-commit.txt
+          git commit -m "automatic update of open bus stride api dependencies"
+          git push origin main
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Clone open-bus-stride-db
+        run: git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -r tests/requirements.txt
+          pip install fastapi uvicorn openapi-generator-cli
+
+      - name: Start database and API server
+        env:
+          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+        run: |
+          cd ../open-bus-stride-db
+          docker-compose up -d stride-db
+          . .env && alembic upgrade head
+          cd ../../${GITHUB_WORKSPACE}
+          uvicorn main:app --host 0.0.0.0 --port 8000 &
+          sleep 10 # Wait for server to start
+
+      - name: Generate TypeScript client
+        run: |
+          mkdir -p npm-package
+          openapi-generator-cli generate \
+            -i http://localhost:8000/openapi.json \
+            -g typescript-axios \
+            -o npm-package \
+            --additional-properties=supportsES6=true,npmName=@hasadna/open-bus-stride-api-client
+          cd npm-package
+          npm install typescript --save-dev
+          npm install axios
+          npx tsc --init
+          npm install
+
+      - name: Set package version
+        run: |
+          cd npm-package
+          SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-7)
+          VERSION="1.0.0-$SHORT_SHA"
+          npm version $VERSION --no-git-tag-version
+
+      - name: Check if version exists and publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd npm-package
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          if npm view @hasadna/open-bus-stride-api-client@$VERSION > /dev/null 2>&1; then
+            echo "Version $VERSION already exists, skipping publish"
+          else
+            npm publish --access public
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,78 +5,83 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 jobs:
   ci:
+    name: CI Open Bus Stride API 
+    id: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-      - env:
-          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
-          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
-          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
-      - run: |
-          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db &&\
-          pip install -r requirements-dev.txt &&\
-          pip install -r tests/requirements.txt &&\
-          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin &&\
-          if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
-            CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"
-          else
-            CACHE_FROM_ARG=""
-          fi &&\
-          docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app . &&\
-          docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
-          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
-          pytest &&\
-          if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
-            docker tag app "${DOCKER_APP_IMAGE_NAME}:latest" &&\
-            docker push "${DOCKER_APP_IMAGE_NAME}:latest" &&\
-            if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
-              cd `mktemp -d` &&\
-              echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key &&\
-              chmod 400 hasadna_k8s_deploy_key &&\
-              export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
-              git clone git@github.com:hasadna/hasadna-k8s.git &&\
-              cd hasadna-k8s &&\
-              python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml &&\
-              git config --global user.name "Open Bus Stride API CI" &&\
-              git config --global user.email "open-bus-stride-api-ci@localhost" &&\
-              git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api" &&\
-              git push origin master &&\
-              echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key &&\
-              chmod 400 stride_etl_deploy_key &&\
-              export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
-              git clone git@github.com:hasadna/open-bus-stride-etl.git &&\
-              cd open-bus-stride-etl &&\
-              echo "${GITHUB_SHA}" > stride-api-latest-commit.txt &&\
-              git add stride-api-latest-commit.txt &&\
-              git commit -m "automatic update of open bus stride api dependencies" &&\
-              git push origin main
-              COMMIT_MSG="${{ github.event.head_commit.message }}"
-              FRAGMENT=""
-              if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
-                FRAGMENT="skip"
-              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
-                FRAGMENT="none"
-              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
-                FRAGMENT="patch"
-              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
-                FRAGMENT="minor"
-              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-major'; then
-                FRAGMENT="major"
-              fi
-              echo "fragment=$FRAGMENT" >> "$GITHUB_OUTPUT"
-
-              fi
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+    - env:
+        DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
+        SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+        STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
+      run: |
+        git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db &&\
+        pip install -r requirements-dev.txt &&\
+        pip install -r tests/requirements.txt &&\
+        echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin &&\
+        if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
+          CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"
+        else
+          CACHE_FROM_ARG=""
+        fi &&\
+        docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app . &&\
+        docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
+        docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
+        pytest &&\
+        if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
+          docker tag app "${DOCKER_APP_IMAGE_NAME}:latest" &&\
+          docker push "${DOCKER_APP_IMAGE_NAME}:latest" &&\
+          if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
+            cd `mktemp -d` &&\
+            echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key &&\
+            chmod 400 hasadna_k8s_deploy_key &&\
+            export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
+            git clone git@github.com:hasadna/hasadna-k8s.git &&\
+            cd hasadna-k8s &&\
+            python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml &&\
+            git config --global user.name "Open Bus Stride API CI" &&\
+            git config --global user.email "open-bus-stride-api-ci@localhost" &&\
+            git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api" &&\
+            git push origin master &&\
+            echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key &&\
+            chmod 400 stride_etl_deploy_key &&\
+            export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
+            git clone git@github.com:hasadna/open-bus-stride-etl.git &&\
+            cd open-bus-stride-etl &&\
+            echo "${GITHUB_SHA}" > stride-api-latest-commit.txt &&\
+            git add stride-api-latest-commit.txt &&\
+            git commit -m "automatic update of open bus stride api dependencies" &&\
+            git push origin main
+            COMMIT_MSG="${{ github.event.head_commit.message }}"
+            FRAGMENT=""
+            if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
+              FRAGMENT="skip"
+            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
+              FRAGMENT="none"
+            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
+              FRAGMENT="patch"
+            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
+              FRAGMENT="minor"
+            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-major'; then
+              FRAGMENT="major"
+            fi
+            echo "fragment=$FRAGMENT" >> $GITHUB_OUTPUT
           fi
-      - name: Generate Open Bus API Client
-        if: GITHUB_REF  == 'refs/heads/main'  && steps.generate_client.outputs.fragment != ''
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: hasadna/open-bus-api-client
-          event-type: generate-client
-          client-payload: { "semver-fragment": "${{ FRAGMENT }}" }
+        fi
+
+    - name: Generate Open Bus API Client
+      if: github.ref == 'refs/heads/main' && steps.ci.outputs.fragment
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: hasadna/open-bus-api-client
+        event-type: generate-client
+        client-payload: |
+          {
+            "semver-fragment": "${{ steps.compute-fragment.outputs.fragment }}"
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - name: CI Open Bus Stride API 
-    - id: ci
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v5
       with:
         python-version: '3.8'
-    - env:
+    - id: ci
+      env:
         DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
@@ -59,11 +58,7 @@ jobs:
             git push origin main
             COMMIT_MSG="${{ github.event.head_commit.message }}"
             FRAGMENT=""
-            if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
-              FRAGMENT="skip"
-            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
-              FRAGMENT="none"
-            elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
+            if echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
               FRAGMENT="patch"
             elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
               FRAGMENT="minor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,32 @@ jobs:
             git push origin main
           fi
 
+      - name: Extract semver-fragment from commit message
+        id: extract
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          FRAGMENT=""
+           if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
+            FRAGMENT="skip"
+          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
+            FRAGMENT="none"
+          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
+            FRAGMENT="patch"
+          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
+            FRAGMENT="minor"
+          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-major'; then
+            FRAGMENT="major"
+          fi
+          echo "semver-fragment=$FRAGMENT" >> "$GITHUB_OUTPUT"
+
       - name: Trigger client generation
+        if: ${{ steps.extract.outputs.semver-fragment != '' }}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: hasadna/open-bus-api-client
           event-type: generate-client
-          client-payload: '{"version": "${GITHUB_SHA}"}'
+          client-payload: >-
+            {
+              "semver-fragment": "${{ steps.extract.outputs.semver-fragment }}"
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 jobs:
   ci:
-    name: CI Open Bus Stride API 
-    id: ci
     runs-on: ubuntu-latest
     steps:
+    - name: CI Open Bus Stride API 
+    - id: ci
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v5
       with:
@@ -83,5 +83,5 @@ jobs:
         event-type: generate-client
         client-payload: |
           {
-            "semver-fragment": "${{ steps.compute-fragment.outputs.fragment }}"
+            "semver-fragment": "${{ steps.ci.outputs.fragment }}"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,132 +3,80 @@ on:
   push:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
-
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v5
         with:
           python-version: "3.8"
-      - name: Clone DB and Install Dependencies
-        run: |
-          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-          pip install -r requirements-dev.txt
-          pip install -r tests/requirements.txt
-      - name: Docker Login
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
-      - name: Build Docker Image
-        env:
+      - env:
           DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-        run: |
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
+          SQLALCHEMY_URL: ${{ secrets.SQLALCHEMY_URL }}
+          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
+      - run: |
+          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db &&\
+          pip install -r requirements-dev.txt &&\
+          pip install -r tests/requirements.txt &&\
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin &&\
           if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
             CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"
           else
             CACHE_FROM_ARG=""
+          fi &&\
+          docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app . &&\
+          docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
+          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}" &&\
+          pytest &&\
+          if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
+            docker tag app "${DOCKER_APP_IMAGE_NAME}:latest" &&\
+            docker push "${DOCKER_APP_IMAGE_NAME}:latest" &&\
+            if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
+              cd `mktemp -d` &&\
+              echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key &&\
+              chmod 400 hasadna_k8s_deploy_key &&\
+              export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
+              git clone git@github.com:hasadna/hasadna-k8s.git &&\
+              cd hasadna-k8s &&\
+              python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml &&\
+              git config --global user.name "Open Bus Stride API CI" &&\
+              git config --global user.email "open-bus-stride-api-ci@localhost" &&\
+              git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api" &&\
+              git push origin master &&\
+              echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key &&\
+              chmod 400 stride_etl_deploy_key &&\
+              export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
+              git clone git@github.com:hasadna/open-bus-stride-etl.git &&\
+              cd open-bus-stride-etl &&\
+              echo "${GITHUB_SHA}" > stride-api-latest-commit.txt &&\
+              git add stride-api-latest-commit.txt &&\
+              git commit -m "automatic update of open bus stride api dependencies" &&\
+              git push origin main
+              COMMIT_MSG="${{ github.event.head_commit.message }}"
+              FRAGMENT=""
+              if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
+                FRAGMENT="skip"
+              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
+                FRAGMENT="none"
+              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
+                FRAGMENT="patch"
+              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
+                FRAGMENT="minor"
+              elif echo "$COMMIT_MSG" | grep -qi -- '--generate-major'; then
+                FRAGMENT="major"
+              fi
+              echo "fragment=$FRAGMENT" >> "$GITHUB_OUTPUT"
+
+              fi
           fi
-          docker build $CACHE_FROM_ARG --build-arg VERSION=${GITHUB_SHA} -t app .
-          docker tag app "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-      - name: Clone DB and Install Dependencies
-        run: |
-          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-          pip install -r requirements-dev.txt
-          pip install -r tests/requirements.txt
-      - name: Run Tests
-        run: pytest
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: test
-    if: ${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '--no-deploy') }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-      - name: Clone DB and Install Dependencies
-        run: |
-          git clone https://github.com/hasadna/open-bus-stride-db.git ../open-bus-stride-db
-          pip install -r requirements-dev.txt
-          pip install -r tests/requirements.txt
-      - name: Docker Login
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin
-      - name: Push Docker Images
-        env:
-          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-        run: |
-          docker push "${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"
-          docker tag app "${DOCKER_APP_IMAGE_NAME}:latest"
-          docker push "${DOCKER_APP_IMAGE_NAME}:latest"
-      - name: Deploy to K8s & Update ETL
-        env:
-          HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
-          STRIDE_ETL_DEPLOY_KEY: ${{ secrets.STRIDE_ETL_DEPLOY_KEY }}
-          DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api"
-        run: |
-          if ! git log -1 --pretty=format:"%s" | grep -- --no-deploy; then
-            cd `mktemp -d`
-            echo "${HASADNA_K8S_DEPLOY_KEY}" > hasadna_k8s_deploy_key
-            chmod 400 hasadna_k8s_deploy_key
-            export GIT_SSH_COMMAND="ssh -i `pwd`/hasadna_k8s_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-            git clone git@github.com:hasadna/hasadna-k8s.git
-            cd hasadna-k8s
-            python update_yaml.py '{"strideApiImage":"'"${DOCKER_APP_IMAGE_NAME}:${GITHUB_SHA}"'"}' apps/openbus/values-hasadna-auto-updated.yaml
-            git config --global user.name "Open Bus Stride API CI"
-            git config --global user.email "open-bus-stride-api-ci@localhost"
-            git add apps/openbus/values-hasadna-auto-updated.yaml && git commit -m "automatic update of open bus stride api"
-            git push origin master
-            echo "${STRIDE_ETL_DEPLOY_KEY}" > stride_etl_deploy_key
-            chmod 400 stride_etl_deploy_key
-            export GIT_SSH_COMMAND="ssh -i `pwd`/stride_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-            git clone git@github.com:hasadna/open-bus-stride-etl.git
-            cd open-bus-stride-etl
-            echo "${GITHUB_SHA}" > stride-api-latest-commit.txt
-            git add stride-api-latest-commit.txt
-            git commit -m "automatic update of open bus stride api dependencies"
-            git push origin main
-          fi
-
-      - name: Extract semver-fragment from commit message
-        id: extract
-        run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          FRAGMENT=""
-           if echo "$COMMIT_MSG" | grep -qi -- '--generate-skip'; then
-            FRAGMENT="skip"
-          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-none'; then
-            FRAGMENT="none"
-          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-patch'; then
-            FRAGMENT="patch"
-          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-minor'; then
-            FRAGMENT="minor"
-          elif echo "$COMMIT_MSG" | grep -qi -- '--generate-major'; then
-            FRAGMENT="major"
-          fi
-          echo "semver-fragment=$FRAGMENT" >> "$GITHUB_OUTPUT"
-
-      - name: Trigger client generation
-        if: ${{ steps.extract.outputs.semver-fragment != '' }}
+      - name: Generate Open Bus API Client
+        if: GITHUB_REF  == 'refs/heads/main'  && steps.generate_client.outputs.fragment != ''
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: hasadna/open-bus-api-client
           event-type: generate-client
-          client-payload: >-
-            {
-              "semver-fragment": "${{ steps.extract.outputs.semver-fragment }}"
-            }
+          client-payload: { "semver-fragment": "${{ FRAGMENT }}" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '--no-deploy') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v5
@@ -102,3 +102,11 @@ jobs:
             git commit -m "automatic update of open bus stride api dependencies"
             git push origin main
           fi
+
+      - name: Trigger client generation
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: hasadna/open-bus-api-client
+          event-type: generate-client
+          client-payload: '{"version": "${GITHUB_SHA}"}'

--- a/README.md
+++ b/README.md
@@ -125,13 +125,11 @@ This controls automatic generation of a client API package in the [open-bus-api-
 
 Include one of the following flags in your commit message:
 
-| Commit Flag         | Behavior                                      |
-|---------------------|-----------------------------------------------|
-| `--generate-none`   | Runs the generate workflow, but skips publish |
-| `--generate-skip`   | Generates client, but skip version bump       |
-| `--generate-patch`  | Generates client and bumps patch version      |
-| `--generate-minor`  | Generates client and bumps minor version      |
-| `--generate-major`  | Generates client and bumps major version      |
+| Commit Flag        | Behavior                                 |
+| ------------------ | ---------------------------------------- |
+| `--generate-patch` | Generates client and bumps patch version |
+| `--generate-minor` | Generates client and bumps minor version |
+| `--generate-major` | Generates client and bumps major version |
 
 **Example commit:**
 

--- a/README.md
+++ b/README.md
@@ -1,119 +1,176 @@
-# Open Bus Stride API
+# 🚌 Open Bus Stride API
 
-API For the [Open Bus Stride project](https://open-bus-map-search.hasadna.org.il/dashboard)
+**An API for the [Open Bus Stride Project](https://open-bus-map-search.hasadna.org.il/dashboard)**
 
-* Please report issues and feature requests [here](https://github.com/hasadna/open-bus/issues/new)
-* To get updates about the system status and for general help join Hasadna's Slack #open-bus channel ([Hasadna Slack signup link](https://join.slack.com/t/hasadna/shared_invite/zt-167h764cg-J18ZcY1odoitq978IyMMig))
+---
 
-See [our contributing docs](https://github.com/hasadna/open-bus-pipelines/blob/main/CONTRIBUTING.md) if you want to suggest changes to this repository.
+## 📢 Get Involved
 
+- 💬 For general help and system updates, join the Hasadna Slack: [#open-bus channel](https://join.slack.com/t/hasadna/shared_invite/zt-167h764cg-J18ZcY1odoitq978IyMMig)
+- 🐞 Found a bug or have a feature request? [Open an issue](https://github.com/hasadna/open-bus-map-search/issues/new)
+- 🤝 Want to contribute? See our [contributing guidelines](https://github.com/hasadna/open-bus-pipelines/blob/main/CONTRIBUTING.md)
 
-## Tech Stack
+---
 
-- [python](https://www.python.org/)
-- [fastAPI framework](https://fastapi.tiangolo.com/)
-- [postgresql](https://www.postgresql.org/)
+## 🔗 Related Projects
 
+### Frontend
+* [🗺️ Open Bus Map Search (Client App)](https://github.com/hasadna/open-bus-map-search) - [Live Website](https://open-bus-map-search.hasadna.org.il/dashboard)
+* [📦 Open Bus API Client (API Package Generator)](https://github.com/hasadna/open-bus-api-client)
 
-## Development using the Docker Compose environment
+### Backend
+* [🏗️ Open Bus Pipelines](https://github.com/hasadna/open-bus-pipelines)
+* [🌐 Open Bus Stride API (REST)](https://github.com/hasadna/open-bus-stride-api) – [API Docs](https://open-bus-stride-api.hasadna.org.il/docs)
+* [🧾 Open Bus Stride DB](https://github.com/hasadna/open-bus-stride-db)
+* [🔧 Open Bus Stride ETL](https://github.com/hasadna/stride-etl)
+* [📚 Open Bus GTFS ETL](https://github.com/hasadna/gtfs-etl)
+* [📡 Open Bus SIRI Requester](https://github.com/hasadna/siri-requester)
+* [🧪 Open Bus SIRI ETL](https://github.com/hasadna/siri-etl)
 
-This is the easiest option to start development, follow these instructions: https://github.com/hasadna/open-bus-pipelines/blob/main/README.md#stride-api
+---
 
-For local development, see the additional functionality section: `Develop stride-api from a local clone`
+## 🛠️ Tech Stack
 
-## Local Development
+- [Python](https://www.python.org/)
+- [FastAPI](https://fastapi.tiangolo.com/)
+- [PostgreSQL](https://www.postgresql.org/)
 
-It's much easier to use the Docker Compose environment, but the following can be
-refferd to for more details regarding the internal processes and for development
-using your local Python interpreter. 
+---
 
-### Install
+## 🚀 Getting Started
 
-Create a virtualenv (using Python 3.8)
+### Option 1: Using Docker Compose (Recommended)
 
-```
+The easiest way to get up and running is with Docker Compose.  
+Follow the instructions [here](https://github.com/hasadna/open-bus-pipelines/blob/main/README.md#stride-api).
+
+For local development (e.g. making changes to the code), also see:  
+**`Develop stride-api from a local clone`** in the same document.
+
+---
+
+### Option 2: Local Development (Manual Setup)
+
+Use this if you prefer to run directly from your local Python environment.
+
+#### 1. Clone and Setup
+
+Ensure you have **Python 3.8** installed.
+
+```bash
 python3.8 -m venv venv
-```
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+````
 
-Update pip
-
-```
-venv/bin/pip install --upgrade pip
-```
-
-You should have a copy of open-bus-stride-db repository at ../open-bus-stride-db
-
-Install dependencies
+Ensure a local clone of [open-bus-stride-db](https://github.com/hasadna/open-bus-stride-db) exists at:
 
 ```
-venv/bin/pip install -r requirements-dev.txt 
+../open-bus-stride-db
 ```
 
-### Use
+#### 2. Database Connection
 
-You need a DB to connect to, there are 2 options here:
+You’ll need a database. You have two options:
 
-* Start the stride-db from open-bus-pipelines docker-compose environment
-* Connect to the production DB using the Redash read-only credentials
-  * Create a `.env` file with the following, replacing the url to the production redash read-only url: `export SQLALCHEMY_URL=postgresql://postgres:123456@localhost`
-  * Source the .env: `. .env`
+* **Option A**: Start `stride-db` using the Docker Compose environment from [open-bus-pipelines](https://github.com/hasadna/open-bus-pipelines).
+* **Option B**: Connect to the production DB using Redash read-only credentials.
 
-Activate virtualenv
+Create a `.env` file:
 
-```
-. venv/bin/activate
+```env
+export SQLALCHEMY_URL=postgresql://postgres:123456@localhost
 ```
 
-Start the FastAPI server with automatic reload on changes
+Then source it:
 
+```bash
+. .env
 ```
+
+#### 3. Run the API Server
+
+```bash
 uvicorn open_bus_stride_api.main:app --reload
 ```
 
-See the API docs at http://localhost:8000/docs
+Access the interactive API docs at:
+👉 [http://localhost:8000/docs](http://localhost:8000/docs)
 
-### Manage APIs
+---
 
-All existing APIs from the docs are defined under ```open_bus_stride_api/routers/<base_router_name>.py```
+## 🧩 API Development
 
-Follow this example to create or edit a simple API for a specific table with filters: 
-
+All routes are defined in:
 
 ```
-@router.<http_method>("/<api_path>", tags=[<file_name>], response_model=<pydantic_response_model>) // 
-def name(<filtering_params>, limit, offset): # always include limit & offest to allow easy iteration on the data
+open_bus_stride_api/routers/<base_router_name>.py
+```
+
+### ✍️ Example API
+
+```python
+@router.<http_method>("/<api_path>", tags=["<tag_name>"], response_model=<ResponseModel>)
+def name(<filtering_params>, limit, offset):
     return common.get_list(
-        <db_model>, limit, offset,
-        [   
-            {'type': <filter_type>, 'field': <db_stcruct>.<specific_id>, 'value': <filter_param>},
+        <DBModel>, limit, offset,
+        [
+            {'type': <filter_type>, 'field': <DBModel>.<field>, 'value': <filter_param>},
         ]
     )
 ```
 
-Filter types are defined at ```open_bus_stride_api/routers/common.py -> get_list_query_filter_<filter_type>``` (e.g.: 'equal', 'date_in_range')
+* **Filters**: Defined in `routers/common.py` → `get_list_query_filter_<filter_type>`
+  (Examples: `'equal'`, `'date_in_range'`)
 
-### Running Tests
+Always include `limit` and `offset` for pagination.
 
-Install for local development as described above.
+---
 
-Install test requirements:
+## 🧪 Running Tests
 
-```
+Set up your environment as described in the **Local Development** section above.
+
+Install test dependencies:
+
+```bash
 pip install -r tests/requirements.txt
 ```
 
-To run the tests you need to connect to a DB with full stride data, 
-easiest way is to connect to the production DB as described above by
-setting the SQLALCHEMY_URL env var accordingly.
+Ensure the DB contains full Stride data (production read-only access works).
 
-Run all tests with full output, exiting on first error:
+Run tests:
 
-```
+```bash
 pytest -svvx
 ```
 
-Pytest has many options, see the help message for details.
+For more options, run:
 
+```bash
+pytest --help
+```
 
-### Link To The Client Repo
-- [client repo](https://github.com/hasadna/open-bus-map-search)
+---
+
+## 🔄 Versioning & Client Generation
+
+When changes are merged into the `main` branch, the commit message is scanned for versioning instructions.
+This controls automatic generation of a client API package in the [open-bus-api-client](https://github.com/hasadna/open-bus-api-client) repository.
+
+Include one of the following flags in your commit message:
+
+| Commit Flag         | Behavior                                      |
+|---------------------|-----------------------------------------------|
+| `--generate-skip`   | Runs the generate workflow, but skips publish |
+| `--generate-none`   | Generates client with no version bump         |
+| `--generate-patch`  | Generates client and bumps patch version      |
+| `--generate-minor`  | Generates client and bumps minor version      |
+| `--generate-major`  | Generates client and bumps major version      |
+
+**Example commit:**
+
+```bash
+git commit -m "Add new field to stops API --generate-minor"
+```

--- a/README.md
+++ b/README.md
@@ -1,158 +1,122 @@
-# 🚌 Open Bus Stride API
+# Open Bus Stride API
 
-**An API for the [Open Bus Stride Project](https://open-bus-map-search.hasadna.org.il/dashboard)**
+API For the [Open Bus Stride project](https://open-bus-map-search.hasadna.org.il/dashboard)
 
----
+* Please report issues and feature requests [here](https://github.com/hasadna/open-bus/issues/new)
+* To get updates about the system status and for general help join Hasadna's Slack #open-bus channel ([Hasadna Slack signup link](https://join.slack.com/t/hasadna/shared_invite/zt-167h764cg-J18ZcY1odoitq978IyMMig))
 
-## 📢 Get Involved
+See [our contributing docs](https://github.com/hasadna/open-bus-pipelines/blob/main/CONTRIBUTING.md) if you want to suggest changes to this repository.
 
-- 💬 For general help and system updates, join the Hasadna Slack: [#open-bus channel](https://join.slack.com/t/hasadna/shared_invite/zt-167h764cg-J18ZcY1odoitq978IyMMig)
-- 🐞 Found a bug or have a feature request? [Open an issue](https://github.com/hasadna/open-bus-map-search/issues/new)
-- 🤝 Want to contribute? See our [contributing guidelines](https://github.com/hasadna/open-bus-pipelines/blob/main/CONTRIBUTING.md)
 
----
+## Tech Stack
 
-## 🔗 Related Projects
+- [python](https://www.python.org/)
+- [fastAPI framework](https://fastapi.tiangolo.com/)
+- [postgresql](https://www.postgresql.org/)
 
-### Frontend
-* [🗺️ Open Bus Map Search (Client App)](https://github.com/hasadna/open-bus-map-search) - [Live Website](https://open-bus-map-search.hasadna.org.il/dashboard)
-* [📦 Open Bus API Client (API Package Generator)](https://github.com/hasadna/open-bus-api-client)
 
-### Backend
-* [🏗️ Open Bus Pipelines](https://github.com/hasadna/open-bus-pipelines)
-* [🌐 Open Bus Stride API (REST)](https://github.com/hasadna/open-bus-stride-api) – [API Docs](https://open-bus-stride-api.hasadna.org.il/docs)
-* [🧾 Open Bus Stride DB](https://github.com/hasadna/open-bus-stride-db)
-* [🔧 Open Bus Stride ETL](https://github.com/hasadna/stride-etl)
-* [📚 Open Bus GTFS ETL](https://github.com/hasadna/gtfs-etl)
-* [📡 Open Bus SIRI Requester](https://github.com/hasadna/siri-requester)
-* [🧪 Open Bus SIRI ETL](https://github.com/hasadna/siri-etl)
+## Development using the Docker Compose environment
 
----
+This is the easiest option to start development, follow these instructions: https://github.com/hasadna/open-bus-pipelines/blob/main/README.md#stride-api
 
-## 🛠️ Tech Stack
+For local development, see the additional functionality section: `Develop stride-api from a local clone`
 
-- [Python](https://www.python.org/)
-- [FastAPI](https://fastapi.tiangolo.com/)
-- [PostgreSQL](https://www.postgresql.org/)
+## Local Development
 
----
+It's much easier to use the Docker Compose environment, but the following can be
+refferd to for more details regarding the internal processes and for development
+using your local Python interpreter. 
 
-## 🚀 Getting Started
+### Install
 
-### Option 1: Using Docker Compose (Recommended)
+Create a virtualenv (using Python 3.8)
 
-The easiest way to get up and running is with Docker Compose.  
-Follow the instructions [here](https://github.com/hasadna/open-bus-pipelines/blob/main/README.md#stride-api).
-
-For local development (e.g. making changes to the code), also see:  
-**`Develop stride-api from a local clone`** in the same document.
-
----
-
-### Option 2: Local Development (Manual Setup)
-
-Use this if you prefer to run directly from your local Python environment.
-
-#### 1. Clone and Setup
-
-Ensure you have **Python 3.8** installed.
-
-```bash
+```
 python3.8 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-pip install --upgrade pip
-pip install -r requirements-dev.txt
-````
-
-Ensure a local clone of [open-bus-stride-db](https://github.com/hasadna/open-bus-stride-db) exists at:
-
-```
-../open-bus-stride-db
 ```
 
-#### 2. Database Connection
+Update pip
 
-You’ll need a database. You have two options:
-
-* **Option A**: Start `stride-db` using the Docker Compose environment from [open-bus-pipelines](https://github.com/hasadna/open-bus-pipelines).
-* **Option B**: Connect to the production DB using Redash read-only credentials.
-
-Create a `.env` file:
-
-```env
-export SQLALCHEMY_URL=postgresql://postgres:123456@localhost
+```
+venv/bin/pip install --upgrade pip
 ```
 
-Then source it:
+You should have a copy of open-bus-stride-db repository at ../open-bus-stride-db
 
-```bash
-. .env
+Install dependencies
+
+```
+venv/bin/pip install -r requirements-dev.txt 
 ```
 
-#### 3. Run the API Server
+### Use
 
-```bash
+You need a DB to connect to, there are 2 options here:
+
+* Start the stride-db from open-bus-pipelines docker-compose environment
+* Connect to the production DB using the Redash read-only credentials
+  * Create a `.env` file with the following, replacing the url to the production redash read-only url: `export SQLALCHEMY_URL=postgresql://postgres:123456@localhost`
+  * Source the .env: `. .env`
+
+Activate virtualenv
+
+```
+. venv/bin/activate
+```
+
+Start the FastAPI server with automatic reload on changes
+
+```
 uvicorn open_bus_stride_api.main:app --reload
 ```
 
-Access the interactive API docs at:
-👉 [http://localhost:8000/docs](http://localhost:8000/docs)
+See the API docs at http://localhost:8000/docs
 
----
+### Manage APIs
 
-## 🧩 API Development
+All existing APIs from the docs are defined under ```open_bus_stride_api/routers/<base_router_name>.py```
 
-All routes are defined in:
+Follow this example to create or edit a simple API for a specific table with filters: 
+
 
 ```
-open_bus_stride_api/routers/<base_router_name>.py
-```
-
-### ✍️ Example API
-
-```python
-@router.<http_method>("/<api_path>", tags=["<tag_name>"], response_model=<ResponseModel>)
-def name(<filtering_params>, limit, offset):
+@router.<http_method>("/<api_path>", tags=[<file_name>], response_model=<pydantic_response_model>) // 
+def name(<filtering_params>, limit, offset): # always include limit & offest to allow easy iteration on the data
     return common.get_list(
-        <DBModel>, limit, offset,
-        [
-            {'type': <filter_type>, 'field': <DBModel>.<field>, 'value': <filter_param>},
+        <db_model>, limit, offset,
+        [   
+            {'type': <filter_type>, 'field': <db_stcruct>.<specific_id>, 'value': <filter_param>},
         ]
     )
 ```
 
-* **Filters**: Defined in `routers/common.py` → `get_list_query_filter_<filter_type>`
-  (Examples: `'equal'`, `'date_in_range'`)
+Filter types are defined at ```open_bus_stride_api/routers/common.py -> get_list_query_filter_<filter_type>``` (e.g.: 'equal', 'date_in_range')
 
-Always include `limit` and `offset` for pagination.
+### Running Tests
 
----
+Install for local development as described above.
 
-## 🧪 Running Tests
+Install test requirements:
 
-Set up your environment as described in the **Local Development** section above.
-
-Install test dependencies:
-
-```bash
+```
 pip install -r tests/requirements.txt
 ```
 
-Ensure the DB contains full Stride data (production read-only access works).
+To run the tests you need to connect to a DB with full stride data, 
+easiest way is to connect to the production DB as described above by
+setting the SQLALCHEMY_URL env var accordingly.
 
-Run tests:
+Run all tests with full output, exiting on first error:
 
-```bash
+```
 pytest -svvx
 ```
 
-For more options, run:
+Pytest has many options, see the help message for details.
 
-```bash
-pytest --help
-```
 
----
+### Link To The Client Repo
+- [client repo](https://github.com/hasadna/open-bus-map-search)
 
 ## 🔄 Versioning & Client Generation
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Pytest has many options, see the help message for details.
 ### Link To The Client Repo
 - [client repo](https://github.com/hasadna/open-bus-map-search)
 
-## 🔄 Versioning & Client Generation
+## 🔄 Generation & Publish Client Api Package
 
 When changes are merged into the `main` branch, the commit message is scanned for versioning instructions.
 This controls automatic generation of a client API package in the [open-bus-api-client](https://github.com/hasadna/open-bus-api-client) repository.
@@ -127,8 +127,8 @@ Include one of the following flags in your commit message:
 
 | Commit Flag         | Behavior                                      |
 |---------------------|-----------------------------------------------|
-| `--generate-skip`   | Runs the generate workflow, but skips publish |
-| `--generate-none`   | Generates client with no version bump         |
+| `--generate-none`   | Runs the generate workflow, but skips publish |
+| `--generate-skip`   | Generates client, but skip version bump       |
 | `--generate-patch`  | Generates client and bumps patch version      |
 | `--generate-minor`  | Generates client and bumps minor version      |
 | `--generate-major`  | Generates client and bumps major version      |


### PR DESCRIPTION
* Added a trigger to generate the **client API package**.
* Add Information about Client Generation to the Readme.

## 🔄 Client Generation

When changes are merged into the `main` branch, the commit message is scanned for **versioning flags** that control the automatic generation of the client API package in the [open-bus-api-client](https://github.com/hasadna/open-bus-api-client) repository.

### Supported Commit Flags

| Commit Flag         | Behavior                                      |
|---------------------|-----------------------------------------------|
| `--generate-patch`  | Generates client and bumps patch version      |
| `--generate-minor`  | Generates client and bumps minor version      |
| `--generate-major`  | Generates client and bumps major version      |

### Example commit message

```bash
git commit -m "Add new field to stops API --generate-minor"
```
