### PR TITLE
fix: use Israel midnight for date filtering in rides_execution

### DIFF
--- a/open_bus_stride_api/routers/rides_execution.py
+++ b/open_bus_stride_api/routers/rides_execution.py
@@ -44,7 +44,7 @@ def list_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
             where
                 sr.operator_ref = :operator_ref
                 and sr.line_ref = :line_ref
-                and date_trunc('day', siri_ride.scheduled_start_time) between :date_from and :date_to
+                and date_trunc('day', siri_ride.scheduled_start_time AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Jerusalem') between :date_from and :date_to
             ) actual_rides
         full outer join
             (select 
@@ -55,7 +55,7 @@ def list_(limit: int = common.param_limit(default_limit=DEFAULT_LIMIT),
             where
                 gr.operator_ref = :operator_ref
                 and gr.line_ref = :line_ref
-                and date_trunc('day', gtfs_ride.start_time) between :date_from and :date_to
+                and date_trunc('day', gtfs_ride.start_time AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Jerusalem') between :date_from and :date_to
             ) planned_rides
         on
             actual_rides.start_time = planned_rides.start_time


### PR DESCRIPTION
Fixes #54
  Related: hasadna/open-bus-map-search#821                                                                                                                   
                                                                                                                                                             
  Two-line fix: 
adds `AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Jerusalem'` to both `date_trunc` calls in `rides_execution.py`, so day boundaries align with     
  Israel midnight instead of UTC midnight.                                                                                                                   

  See #54 for full reproduction steps and proof.
