### PR TITLE
docs: fix backwards setup order, clarify gunicorn serves production

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,20 @@ Use this if you prefer to run directly from your local Python environment.
 
 Ensure you have **Python 3.8** installed.
 
+Ensure a local clone of [open-bus-stride-db](https://github.com/hasadna/open-bus-stride-db) exists at:
+
+```
+../open-bus-stride-db
+```
+
+`requirements-dev.txt` installs it as an editable dependency, so it must already
+be cloned before the next step.
+
 ```bash
 python3.8 -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install --upgrade pip
 pip install -r requirements-dev.txt
-```
-
-Ensure a local clone of [open-bus-stride-db](https://github.com/hasadna/open-bus-stride-db) exists at:
-
-```
-../open-bus-stride-db
 ```
 
 #### 2. Database Connection
@@ -86,6 +89,10 @@ Then source it:
 ```bash
 uvicorn open_bus_stride_api.main:app --reload
 ```
+
+This is for local development (`--reload` picks up code changes). In Docker/production
+the app is served via `gunicorn` with a `uvicorn` worker class instead - see the
+`ENTRYPOINT` in [Dockerfile](Dockerfile) and [gunicorn_conf.py](gunicorn_conf.py).
 
 Access the interactive API docs at:
 👉 [http://localhost:8000/docs](http://localhost:8000/docs)


### PR DESCRIPTION
## Problems
1. The "Local Development (Manual Setup)" section tells the reader to run `pip install -r requirements-dev.txt` (which does `-e ../open-bus-stride-db`) *before* telling them to clone that sibling repo at `../open-bus-stride-db`. Following the steps in order fails on the pip install.
2. "Run the API Server" only shows `uvicorn open_bus_stride_api.main:app --reload`. That's fine for local dev, but the Dockerfile's actual `ENTRYPOINT` runs `gunicorn -k uvicorn.workers.UvicornWorker -c gunicorn_conf.py open_bus_stride_api.main:app` - the README doesn't mention this at all, which could surprise anyone trying to reproduce production behavior locally or debug a Docker-specific issue.

## Fix
- Reordered so the sibling-clone instruction comes before the `pip install` step that depends on it.
- Added a short note after the `uvicorn --reload` example clarifying it's for local dev only, and pointing to the Dockerfile/gunicorn_conf.py for how production actually serves the app.

## Test plan
- [x] Verified against current source: `requirements-dev.txt` (`-e ../open-bus-stride-db`), `Dockerfile` (`ENTRYPOINT ["gunicorn", ...]`).
- [x] Docs-only change, no functional code touched.