### PR TITLE
fix: dedupe /gtfs_agencies/list and require date_from

### DIFF
--- a/open_bus_stride_api/routers/gtfs_agencies.py
+++ b/open_bus_stride_api/routers/gtfs_agencies.py
@@ -1,6 +1,7 @@
 import datetime
 from textwrap import dedent
 
+import fastapi
 import pydantic
 from fastapi import APIRouter
 
@@ -27,31 +28,64 @@ PYDANTIC_MODEL = GtfsAgencyPydanticModel
 @common.router_list(router, TAG, PYDANTIC_MODEL, WHAT_PLURAL)
 def list_(limit: int = common.param_limit(),
           offset: int = common.param_offset(),
-          date_from: datetime.date = common.doc_param('date', filter_type='date_from'),
-          date_to: datetime.date = common.doc_param('date', filter_type='date_to')):
+          date_from: datetime.date = fastapi.Query(
+              ...,
+              description='Required. ' + common.FILTER_DOCS['date_from'].format(what_singular='date')),
+          date_to: datetime.date = common.doc_param('date', filter_type='date_to'),
+          merge: bool = fastapi.Query(
+              True,
+              description='When true (the default), return a de-duplicated list with a single row '
+                         'per operator_ref for the requested date range, carrying the agency name '
+                         'from the latest date in the range. When false, return the raw per-date '
+                         'rows (one row per operator per date) - useful for tracking agency '
+                         'presence and renames over time. A date_from without date_to is treated '
+                         'as that single day.')):
     with get_session() as session:
-        if not limit:
-            limit = common.DEFAULT_LIMIT
+        # date_from is required; a missing date_to means "just that one day".
+        if not date_to:
+            date_to = date_from
         if not offset:
             offset = 0
-        res = []
-        wheres = []
-        if date_from:
-            wheres.append("date >= '{}'".format(date_from.strftime('%Y-%m-%d')))
-        if date_to:
-            wheres.append("date <= '{}'".format(date_to.strftime('%Y-%m-%d')))
-        if len(wheres) > 0:
-            where = 'where ' + ' and '.join(wheres)
+        if not limit:
+            # A merged result holds at most one row per operator (a few dozen), so it needs no
+            # default cap; only the un-merged (operators x dates) mode keeps the safety limit.
+            limit = None if merge else common.DEFAULT_LIMIT
+
+        where = "where date >= '{}' and date <= '{}'".format(
+            date_from.strftime('%Y-%m-%d'), date_to.strftime('%Y-%m-%d'))
+
+        params = {'offset': offset}
+        limit_offset = ''
+        if limit is not None:
+            limit_offset += 'limit :limit '
+            params['limit'] = limit
+        limit_offset += 'offset :offset'
+
+        if merge:
+            # DISTINCT ON (operator_ref) ordered by date desc keeps, per operator, its most recent
+            # row in the range; the inner query is then re-sorted by the public order in the outer.
+            query = dedent("""
+                select date, operator_ref, agency_name from (
+                    select distinct on (operator_ref) date, operator_ref, agency_name
+                    from gtfs_route
+                    {where}
+                    order by operator_ref, date desc, agency_name
+                ) as merged
+                order by date, agency_name
+                {limit_offset}
+            """).format(where=where, limit_offset=limit_offset)
         else:
-            where = ''
-        for row in session.execute(dedent("""
-            select date, operator_ref, agency_name
-            from gtfs_route
-            {where}
-            group by date, operator_ref, agency_name
-            order by date, agency_name
-            limit :limit offset :offset
-        """.format(where=where)), dict(limit=limit, offset=offset)):
+            query = dedent("""
+                select date, operator_ref, agency_name
+                from gtfs_route
+                {where}
+                group by date, operator_ref, agency_name
+                order by date, agency_name
+                {limit_offset}
+            """).format(where=where, limit_offset=limit_offset)
+
+        res = []
+        for row in session.execute(query, params):
             res.append(GtfsAgencyPydanticModel(
                 date=row[0],
                 operator_ref=row[1],

--- a/tests/test_gtfs_agencies.py
+++ b/tests/test_gtfs_agencies.py
@@ -1,0 +1,67 @@
+"""Tests for the /gtfs_agencies/list endpoint.
+
+Self-validating: they discover which dates actually hold data (so they pass both against
+the local seed and against the prod-like CI DB) and assert invariants rather than fixed rows.
+"""
+
+# A range wide enough to span all real data; date_to is needed because date_from alone means
+# "just that day". Ordered by date asc, so the sample starts at the earliest populated dates.
+WIDE = {'date_from': '2000-01-01', 'date_to': '2100-01-01'}
+
+
+def _sample_rows(client):
+    # Raw per-date rows (merge=false) give us real (date, operator_ref) pairs to build cases from.
+    res = client.get('/gtfs_agencies/list', params={**WIDE, 'merge': 'false', 'limit': 200})
+    assert res.status_code == 200
+    rows = res.json()
+    assert rows, 'no gtfs agency data available in the test DB'
+    return rows
+
+
+def test_date_from_is_required(client):
+    # A bare call - previously an all-time full-table scan - is now rejected.
+    assert client.get('/gtfs_agencies/list').status_code == 422
+    # date_to alone is not enough either.
+    assert client.get('/gtfs_agencies/list', params={'date_to': '2024-01-01'}).status_code == 422
+
+
+def test_merged_list_has_one_row_per_operator(client):
+    dates = sorted({row['date'] for row in _sample_rows(client)})
+    date_from, date_to = dates[0], dates[-1]
+    res = client.get('/gtfs_agencies/list',
+                     params={'date_from': date_from, 'date_to': date_to, 'merge': 'true'})
+    assert res.status_code == 200
+    operator_refs = [row['operator_ref'] for row in res.json()]
+    # The whole point of the merge: no operator appears twice across the date range.
+    assert len(operator_refs) == len(set(operator_refs)), \
+        'merged agency list must not contain duplicate operator_ref values'
+
+
+def test_date_from_without_date_to_is_a_single_day(client):
+    day = sorted({row['date'] for row in _sample_rows(client)})[0]
+    res = client.get('/gtfs_agencies/list', params={'date_from': day})
+    assert res.status_code == 200
+    rows = res.json()
+    assert rows, 'expected agencies on a known-populated date'
+    assert all(row['date'] == day for row in rows), \
+        'date_from without date_to must return only that single day'
+    operator_refs = [row['operator_ref'] for row in rows]
+    assert len(operator_refs) == len(set(operator_refs))
+    # On a single day, merged and un-merged describe the same set of operators.
+    unmerged = client.get('/gtfs_agencies/list',
+                          params={'date_from': day, 'date_to': day, 'merge': 'false'})
+    assert unmerged.status_code == 200
+    assert set(operator_refs) == {row['operator_ref'] for row in unmerged.json()}
+
+
+def test_merge_collapses_rows_relative_to_raw(client):
+    dates = sorted({row['date'] for row in _sample_rows(client)})
+    if len(dates) < 2:
+        return  # need a multi-day range for this comparison to be meaningful
+    date_from, date_to = dates[0], dates[-1]
+    common = {'date_from': date_from, 'date_to': date_to}
+    merged = client.get('/gtfs_agencies/list', params={**common, 'merge': 'true'}).json()
+    raw = client.get('/gtfs_agencies/list', params={**common, 'merge': 'false', 'limit': 5000}).json()
+    # Every merged operator is a real operator seen in the raw rows, and merging never adds rows.
+    assert {r['operator_ref'] for r in merged} <= {r['operator_ref'] for r in raw}
+    assert len(merged) <= len(raw)


### PR DESCRIPTION
# Description
* Made `date_from` required.
* Default `date_to` to `date_from` if not present.
* Merge (deduplicate) the list for the selected date range (an operator appears only once in the result - if it is present in at least one day in the range).
* If `merge=false` supplied explicitly - the result is not duplicated.

# Why?
The frontend usually need the agency list to populate the operator dropdown.
It only needs the operators that active in a specific date, or in a date range if it displays a week-aggregation for example.