### PR TITLE
fix: start_time_to was bound to end_time instead of start_time

### DIFF
--- a/open_bus_stride_api/routers/gtfs_rides.py
+++ b/open_bus_stride_api/routers/gtfs_rides.py
@@ -61,7 +61,7 @@ gtfs_ride_filter_params = [
     ),
     common.RouteParam(
         'start_time_to', datetime.datetime, common.DocParam('start time to', filter_type='datetime_to'),
-        {'type': 'datetime_to', 'field': model.GtfsRide.end_time},
+        {'type': 'datetime_to', 'field': model.GtfsRide.start_time},
     ),
 ]
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -32,6 +32,25 @@ def test_gtfs_rides(client):
     )
 
 
+def test_gtfs_rides_start_time_to_filters_on_start_time(client):
+    # regression: start_time_to used to filter on end_time, so rides which started
+    # inside the requested range but ended after it were missing from the results
+    items = common.assert_router_list(client, '/gtfs_rides/list')
+    ride = next(
+        (i for i in items if i['start_time'] and i['end_time'] and i['end_time'] > i['start_time']),
+        None
+    )
+    assert ride, 'no gtfs ride which ends later than it starts to test with'
+    res = client.get('/gtfs_rides/list', params={
+        'gtfs_route_id': ride['gtfs_route_id'],
+        'start_time_from': ride['start_time'],
+        'start_time_to': ride['start_time'],
+    })
+    assert res.status_code == 200
+    assert ride['id'] in [i['id'] for i in res.json()], \
+        'ride which starts exactly at start_time_to but ends after it was filtered out'
+
+
 def test_gtfs_routes(client):
     common.assert_router_list_get(
         client, '/gtfs_routes',


### PR DESCRIPTION
# Description
Fixed a bug in the router was feeding the param `start_time_to` on `gtfs_rides` into `model.GtfsRide.end_time`.
Causing every ride that start within the window but ends after it to be excluded.

* Added regression test.

## Example
### 1) how many rides START at exactly 12:00 on 2026-07-20?
```
curl -s 'https://open-bus-stride-api.hasadna.org.il/gtfs_rides/list?start_time_from=2026-07-20T12:00:00%2B03:00&start_time_to=2026-07-20T12:00:00%2B03:00&get_count=true'
```

### 2) ...yet here they are, listed by start_time
```
curl -s 'https://open-bus-stride-api.hasadna.org.il/gtfs_rides/list?start_time_from=2026-07-20T12:00:00%2B03:00&start_time_to=2026-07-20T14:00:00%2B03:00&limit=5&order_by=start_time%20asc' | jq '.[] | {id, start_time, end_time}'
```